### PR TITLE
 testing dynamic workflow runner

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -9,22 +9,17 @@ on:
   pull_request: {}
 
 permissions:
-  # determining CI workflow status (aggregate of all jobs) - read
-  # delete docker oci tarball workflow artifact
   actions: write
   contents: read # checking out the source code
   pull-requests: write # adding labels to PRs
 
 jobs:
-  release-dryrun:
-    name: Release dryrun
-    runs-on: ubuntu-latest
+  dump-env:
+    runs-on:
+#      group: 'Default' groups are only available for Enterprise accounts, organizations owned by enterprise accounts, and organizations using GitHub Teams
+      labels: ${{ (contains( github.event.pull_request.labels.*.name, 'selfishly-hosted-runner') && format('{0}-laptop', github.actor)) || 'ubuntu-latest' }}
     steps:
-      - name: Checkout Source Code
-        uses: actions/checkout@v3
-      - name: Create GH Tag
-        uses: baumac/github-tag-action@1.65.2
+      - name: Dump GitHub context
         env:
-          CUSTOM_TAG: 0.0.999
-          VERBOSE: true
-          DRY_RUN: true
+          GITHUB_CONTEXT: ${{ toJson(github) }}
+        run: echo "GITHUB_CONTEXT"

--- a/README.md
+++ b/README.md
@@ -1,3 +1,9 @@
 # actions-test-repo
+Used for testing GH actions and workflows.
 
-Used for testing GH actions. This is currently being used to test anothrNick/github-tag-action@v1.65.0 with 998 tags.
+## Current Use
+
+Being used to test drive https://github.com/myoung34/docker-github-actions-runner
+
+## Previous Uses
+- Used for testing anothrNick/github-tag-action@v1.65.0 with 998 tags.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,21 @@
+version: '2.3'
+services:
+  worker:
+    image: myoung34/github-runner:latest
+    environment:
+      REPO_URL: https://github.com/baumac/actions-test-repo
+      RUNNER_NAME: baumac-laptop
+      RUNNER_TOKEN: "" # retrieved from https://github.com/baumac/actions-test-repo/settings/actions/runners and clicking "New self-hosted runner"
+      RUNNER_WORKDIR: /tmp/runner/work
+#      RUNNER_GROUP: Default
+      RUNNER_SCOPE: 'repo'
+      LABELS: baumac,baumac-laptop
+    security_opt:
+      # needed on SELinux systems to allow docker container to manage other docker containers
+      - label:disable
+    volumes:
+      - '/var/run/docker.sock:/var/run/docker.sock'
+      - '/tmp/runner:/tmp/runner'
+      # note: a quirk of docker-in-docker is that this path
+      # needs to be the same path on host and inside the container,
+      # docker mgmt cmds run outside of docker but expect the paths from within


### PR DESCRIPTION
POC for dynamically selecting workflow runner based on github context. Relies heavily on https://github.com/myoung34/docker-github-actions-runner


## Pre-req: Self Hosted Runner Setup
1. Create a runner token by navigating to https://github.com/baumac/actions-test-repo/settings/actions/runners and clicking "New self-hosted runner" (this can be done programmatically)
2. Set the `RUNNER_TOKEN` in `docker-compose.yml`
3. Run `docker-compose up`  to create a self hosted runner with the "baumac-laptop" label

## Demo: Dynamic Runner Selection
1. Push a new commit to this branch to trigger the workflow 
2. If the PR has the `selfishly-hosted-runner` label then the workflow is run on a self hosted runner with the "baumac-laptop" label
3. Otherwise the workflow is run on a shared runner

